### PR TITLE
fixed the $class bug

### DIFF
--- a/qatrix.js
+++ b/qatrix.js
@@ -269,10 +269,10 @@ var version = '1.0',
 	function (elem, className, callback)
 	{
 		var match = [],
-			rclass = new RegExp('\\b' + className + '\\b');
+			rclass = new RegExp('\\s' + className + '\\s');
 		$tag(elem, '*', function (item)
 		{
-			if (rclass.test(item.className))
+			if (rclass.test(' ' + item.className + ' '))
 			{
 				match.push(item);
 			}


### PR DESCRIPTION
修正IE6/7/8 下的bug.

``` javascript
$class($('form'), 'add')
```

正常情况不应该返回`<span class="add-on"><span>` 这个元素.
